### PR TITLE
Adds silent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## [Unreleased]
+
+## [0.4.3] - 2023-03-29
+
+- Adds silent mode, if a story is executed or initialized
+  with `silent_story: true` the `after_run` will not be executed.
+  This is meant to be used for additional, optional tasks, like
+  notifications.
+
+- `after_run` is a different stage than run
 ## [0.4.2] - 2022-08-15
 
 Adds rubocop rules

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    storyteller (0.4.2.2)
+    storyteller (0.4.3)
       activesupport
       smart_init
 
@@ -77,4 +77,4 @@ DEPENDENCIES
   storyteller!
 
 BUNDLED WITH
-   2.4.7
+   2.3.17

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Storyteller
 
-version 0.2.0
+version 0.4.3
 
 Run user stories based on a simple DSL
 
@@ -83,7 +83,10 @@ Every Story **must** have at least on step to be able to execute, if no steps ar
 
 Verification steps can be added to check if the Story has concluded successfully.
 
+### Closure
 
+If some activities are nice to have, but not necessary, i.e. Notifying a newly created
+user, the `after_run`s may come in handy.
 
 ## Lifecycle
 
@@ -97,6 +100,8 @@ Verification steps can be added to check if the Story has concluded successfully
     - `step`
   - verification
     - `done_criteria`
+  - closure
+    - `after_run`
 
 
 ## Helper methods
@@ -133,6 +138,41 @@ If bundler is not being used to manage dependencies, install the gem by executin
 Require the gem, if needed 
 
 `require storyteller`
+
+Create your Stories extending from `Storyteller::Story`
+
+```
+class CreateUser < Storyteller::Story
+    initialize_with  :email, :name
+
+    step -> { @user = User.create(email:, name:) }
+    step -> { @user.add_role :member }
+    after_run :send_emails
+
+    def send_emails
+      Mailer.send_email(email:, template: :welcome)
+    end
+ end
+```
+
+Invoke your story
+
+```
+CreateUser.execute(email: 'user@example.com', name: 'Example User')
+
+# Or the new, and execute way
+
+use_case = CreateUser.new(email: 'user@example.com', name: 'Example User')
+use_case.execute
+```
+
+### Silent mode
+
+To disable the `after_run` method add the `silent_story: true` parameter.
+
+`CreateUser.execute(email:, name:, silent_story: true)`
+
+
 
 ## Development
 

--- a/lib/storyteller/version.rb
+++ b/lib/storyteller/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Storyteller
-  VERSION = '0.4.2.2'
+  VERSION = '0.4.3'
 end


### PR DESCRIPTION
If a story is executed or initialized with `silent_story: true` the `after_run` will not be executed.

This is meant to be used for additional, optional tasks, like  notifications.

Example:

```
class CreateUser < Storyteller::Story
    initialize_with  :email, :name

    step -> { @user = User.create(email:, name:) }
    step -> { @user.add_role :member }
    after_run :send_emails

    def send_emails
      Mailer.send_email(email:, template: :welcome)
    end
 end
```

When running the common UseCase you just run `CreateUser.execute(email:, name:)`

But if you want to run the creation, but not notify, which is an additional step that is a nice to have, but not required, you can invoke it like so: `CreateUser.execute(email:, name:, silent_story: true)`

And the `after_run` will be skipped.





