### PR TITLE
ADD: warning logger if story was executed with silent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.4] - 2023-04-06
+
+- Adds Logger warning if Storyteller is executed with silent mode
+
 ## [0.4.3] - 2023-03-29
 
 - Adds silent mode, if a story is executed or initialized

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,10 @@ gemspec
 
 gem 'rake', '~> 13.0'
 
-gem 'rspec', '~> 3.0'
+group :development, :test do
+  gem 'bump'
+  gem 'rubocop-rake'
+  gem 'rubocop-rspec'
+  gem 'rspec', '~> 3.2'
+  gem 'rubocop', '~> 1.21'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    storyteller (0.4.3)
+    storyteller (0.4.4)
       activesupport
       smart_init
 
@@ -70,7 +70,7 @@ PLATFORMS
 DEPENDENCIES
   bump
   rake (~> 13.0)
-  rspec (~> 3.0)
+  rspec (~> 3.2)
   rubocop (~> 1.21)
   rubocop-rake
   rubocop-rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Storyteller
 
-version 0.4.3
+version 0.4.4
 
 Run user stories based on a simple DSL
 

--- a/lib/storyteller.rb
+++ b/lib/storyteller.rb
@@ -3,8 +3,11 @@
 require 'smart_init'
 require 'active_support/all'
 require_relative 'storyteller/version'
+require_relative 'storyteller/logger'
 
 module Storyteller
+  LOGGER = CustomLogger.new
+
   class Error < StandardError; end
 
   class Story
@@ -151,9 +154,16 @@ module Storyteller
       run_callbacks :verification if errors.empty?
       return self unless success?
 
+      log_execution_if_silent_mode
       run_callbacks :after_run unless @silent_story
 
       self
+    end
+
+    def log_execution_if_silent_mode
+      return unless @silent_story
+
+      LOGGER.warn "Story #{self.class.name} has been executed with silent mode"
     end
   end
 end

--- a/lib/storyteller/logger.rb
+++ b/lib/storyteller/logger.rb
@@ -1,0 +1,13 @@
+require 'logger'
+
+module Storyteller
+  class CustomLogger < Logger
+    def initialize
+      super($stdout)
+      self.level = Logger::INFO
+      self.formatter = proc do |severity, datetime, progname, msg|
+        "#{datetime}: [#{severity}] #{progname} - #{msg}\n"
+      end
+    end
+  end
+end

--- a/lib/storyteller/version.rb
+++ b/lib/storyteller/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Storyteller
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/storyteller.gemspec
+++ b/storyteller.gemspec
@@ -36,11 +36,6 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_dependency 'activesupport'
   spec.add_dependency 'smart_init'
-  spec.add_development_dependency 'bump'
-  spec.add_development_dependency 'rspec', '~> 3.2'
-  spec.add_development_dependency 'rubocop', '~> 1.21'
-  spec.add_development_dependency 'rubocop-rake'
-  spec.add_development_dependency 'rubocop-rspec'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
ADD: module `CustomLogger`

example usage:
_when executing story teller with silent_mode:true_
```ruby
SilentStory.execute(spy:, silent_story: true)
```
Example  ouput in console:
```
2023-04-06 12:06:00 -0400: [WARN]  - Story SilentStory has been executed with silent mode
```

Other changes:
- moves development dependecies to gemspec, `Specify development dependencies in Gemfile. (convention:Gemspec/DevelopmentDependencies)`
