### PR TITLE
feat: implement story_name and subject

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    storyteller (0.4.4)
+    storyteller (0.5.0)
       activesupport
       ostruct
       smart_init

--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ user, the `after_run`s may come in handy.
 
 Other methods are included to help define the story
 
-**name** can be used to give the Story a more user story name 
+**story_name** can be used to give the Story a more user story name
 
 **subject** can be used to define which is the main user of a story, so any other method can refer to that user as subject
-    
+
     class BookClosestToMe < Story
-      name 'As a user I want to make a reservation in a restaurant closest to me'
+      story_name 'As a user I want to make a reservation in a restaurant closest to me'
       subject :creator
 
       def creator = user

--- a/lib/storyteller.rb
+++ b/lib/storyteller.rb
@@ -118,6 +118,14 @@ module Storyteller
       verify(arg, &block)
     end
 
+    def self.story_name(value = nil)
+      value ? @story_name = value : @story_name
+    end
+
+    def self.subject(method_name)
+      define_method(:subject) { send(method_name) }
+    end
+
     def success?
       return true if @stage == :success
 

--- a/lib/storyteller/version.rb
+++ b/lib/storyteller/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Storyteller
-  VERSION = "0.4.4"
+  VERSION = "0.5.0"
 end

--- a/spec/storyteller_spec.rb
+++ b/spec/storyteller_spec.rb
@@ -378,5 +378,34 @@ RSpec.describe Storyteller do
       expect(spy1).to have_received(:call)
       expect(spy2).to have_received(:call)
     end
+
+    it "supports story_name" do
+      class NamedStory < Storyteller::Story
+        story_name "As a user I want to do something"
+        step -> {}
+      end
+
+      expect(NamedStory.story_name).to eq("As a user I want to do something")
+    end
+
+    it "returns nil for story_name when not set" do
+      class UnnamedStory < Storyteller::Story
+        step -> {}
+      end
+
+      expect(UnnamedStory.story_name).to be_nil
+    end
+
+    it "supports subject" do
+      class StoryWithSubject < Storyteller::Story
+        initialize_with :user
+        subject :user
+        step -> {}
+      end
+
+      user = double("User") # standard:disable RSpec/VerifiedDoubles
+      story = StoryWithSubject.new(user:)
+      expect(story.subject).to eq(user)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `story_name` — class-level setter/getter for a human-readable story description (avoids overriding `Module#name`)
- `subject` — takes a symbol and defines an instance method `subject` delegating to that attribute, so steps can refer to the main actor generically
- Updated README to use `story_name` instead of `name`
- Added 3 specs covering both methods

## Test plan

- [ ] `NamedStory.story_name` returns the set string
- [ ] `story_name` returns `nil` when not set
- [ ] `story.subject` delegates to the named method